### PR TITLE
feat: Add email and WhatsApp validation to testpreset and testcanva p…

### DIFF
--- a/testcanva.html
+++ b/testcanva.html
@@ -600,6 +600,68 @@
 
 
     <script>
+    // --- VALIDATION LOGIC ---
+    const operatorPrefixes = {
+        'Telkomsel': ['0811', '0812', '0813', '0821', '0822', '0823', '0851', '0852', '0853'],
+        'by.U': ['0851'],
+        'Indosat Ooredoo': ['0814', '0815', '0816', '0855', '0856', '0857', '0858'],
+        'Tri (3)': ['0895', '0896', '0897', '0898', '0899'],
+        'XL Axiata': ['0817', '0818', '0819', '0859', '0877', '0878', '0879'],
+        'Live.On': ['0859'],
+        'Axis': ['0831', '0832', '0833', '0838'],
+        'Smartfren': ['0881', '0882', '0883', '0884', '0885', '0886', '0887', '0888', '0889']
+    };
+    const blacklistedNumbers = ['081234567890'];
+
+    function isInvalidPattern(nomor) {
+        if (blacklistedNumbers.includes(nomor)) return true;
+        const numberPart = nomor.substring(2);
+        if (/(\d)\1{4,}/.test(numberPart)) return true;
+        for (let i = 0; i < numberPart.length - 4; i++) {
+            const sub = numberPart.substring(i, i + 5);
+            const isAscending = '0123456789'.includes(sub);
+            const isDescending = '9876543210'.includes(sub);
+            if (isAscending || isDescending) return true;
+        }
+        const uniqueDigits = new Set(numberPart.split(''));
+        if (uniqueDigits.size < 4) return true;
+        if (/(..)\1\1/.test(numberPart)) return true;
+        return false;
+    }
+
+    function getOperatorFromNumber(nomor) {
+        const prefix = nomor.substring(0, 4);
+        for (const operator in operatorPrefixes) {
+            if (operatorPrefixes[operator].includes(prefix)) {
+                return operator;
+            }
+        }
+        return null;
+    }
+
+    function validatePhoneNumber(nomorHp) {
+        const genericError = { isValid: false, message: 'Silahkan isi dengan nomor yang benar' };
+
+        if (nomorHp.length < 10) {
+            return genericError;
+        }
+
+        const operator = getOperatorFromNumber(nomorHp);
+        if (!operator) {
+            return genericError;
+        }
+
+        const maxLength = operator === 'Tri (3)' ? 13 : 12;
+        if (nomorHp.length > maxLength) {
+            return genericError;
+        }
+
+        if (isInvalidPattern(nomorHp)) {
+            return genericError;
+        }
+
+        return { isValid: true, message: 'Nomor valid.' };
+    }
     document.addEventListener('DOMContentLoaded', function() {
 
         // --- ELEMENTS ---
@@ -1070,6 +1132,18 @@
             // Validasi input dasar
             if (!nama || !whatsapp || !email || !paymentMethodKey) {
                 showInfoModal('Data Belum Lengkap', 'Mohon lengkapi semua data yang diperlukan sebelum melanjutkan.');
+                return;
+            }
+
+            // --- New Validation Rules ---
+            if (!email.endsWith('@gmail.com')) {
+                showInfoModal('Email Tidak Valid', 'Harap gunakan alamat email Gmail yang valid (diakhiri dengan @gmail.com).');
+                return;
+            }
+
+            const phoneValidationResult = validatePhoneNumber(whatsapp);
+            if (!phoneValidationResult.isValid) {
+                showInfoModal('Nomor WhatsApp Tidak Valid', phoneValidationResult.message);
                 return;
             }
         

--- a/testpreset.html
+++ b/testpreset.html
@@ -747,6 +747,68 @@
 
 
     <script>
+    // --- VALIDATION LOGIC ---
+    const operatorPrefixes = {
+        'Telkomsel': ['0811', '0812', '0813', '0821', '0822', '0823', '0851', '0852', '0853'],
+        'by.U': ['0851'],
+        'Indosat Ooredoo': ['0814', '0815', '0816', '0855', '0856', '0857', '0858'],
+        'Tri (3)': ['0895', '0896', '0897', '0898', '0899'],
+        'XL Axiata': ['0817', '0818', '0819', '0859', '0877', '0878', '0879'],
+        'Live.On': ['0859'],
+        'Axis': ['0831', '0832', '0833', '0838'],
+        'Smartfren': ['0881', '0882', '0883', '0884', '0885', '0886', '0887', '0888', '0889']
+    };
+    const blacklistedNumbers = ['081234567890'];
+
+    function isInvalidPattern(nomor) {
+        if (blacklistedNumbers.includes(nomor)) return true;
+        const numberPart = nomor.substring(2);
+        if (/(\d)\1{4,}/.test(numberPart)) return true;
+        for (let i = 0; i < numberPart.length - 4; i++) {
+            const sub = numberPart.substring(i, i + 5);
+            const isAscending = '0123456789'.includes(sub);
+            const isDescending = '9876543210'.includes(sub);
+            if (isAscending || isDescending) return true;
+        }
+        const uniqueDigits = new Set(numberPart.split(''));
+        if (uniqueDigits.size < 4) return true;
+        if (/(..)\1\1/.test(numberPart)) return true;
+        return false;
+    }
+
+    function getOperatorFromNumber(nomor) {
+        const prefix = nomor.substring(0, 4);
+        for (const operator in operatorPrefixes) {
+            if (operatorPrefixes[operator].includes(prefix)) {
+                return operator;
+            }
+        }
+        return null;
+    }
+
+    function validatePhoneNumber(nomorHp) {
+        const genericError = { isValid: false, message: 'Silahkan isi dengan nomor yang benar' };
+
+        if (nomorHp.length < 10) {
+            return genericError;
+        }
+
+        const operator = getOperatorFromNumber(nomorHp);
+        if (!operator) {
+            return genericError;
+        }
+
+        const maxLength = operator === 'Tri (3)' ? 13 : 12;
+        if (nomorHp.length > maxLength) {
+            return genericError;
+        }
+
+        if (isInvalidPattern(nomorHp)) {
+            return genericError;
+        }
+
+        return { isValid: true, message: 'Nomor valid.' };
+    }
     document.addEventListener('DOMContentLoaded', function() {
 
         // --- ELEMENTS ---
@@ -1288,6 +1350,18 @@
 
             if (!nama || !whatsapp || !email || !paymentMethodKey) {
                 showInfoModal('Data Belum Lengkap', 'Mohon lengkapi semua data yang diperlukan sebelum melanjutkan.');
+                return;
+            }
+
+            // --- New Validation Rules ---
+            if (!email.endsWith('@gmail.com')) {
+                showInfoModal('Email Tidak Valid', 'Harap gunakan alamat email Gmail yang valid (diakhiri dengan @gmail.com).');
+                return;
+            }
+
+            const phoneValidationResult = validatePhoneNumber(whatsapp);
+            if (!phoneValidationResult.isValid) {
+                showInfoModal('Nomor WhatsApp Tidak Valid', phoneValidationResult.message);
                 return;
             }
 


### PR DESCRIPTION
…ages

Copied the existing validation logic from `testindrive.html` and applied it to `testpreset.html` and `testcanva.html`.

This change includes:
- Adding WhatsApp number validation to check for correct prefixes, length, and common invalid patterns.
- Adding email validation to ensure the email address ends with `@gmail.com` to match the requirement from `testindrive.html`.

This ensures that user input on these pages is validated before being submitted, improving data quality.